### PR TITLE
Add copy button to code examples

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,12 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',  # parsing of Numpy docstrings
+    'sphinx_copybutton',  # add copy button to code examples
 ]
+
+# Configure copybutton to strip >>> when copying code
+copybutton_prompt_text = r">>> |\.\.\. "
+copybutton_prompt_is_regexp = True
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ doc = [
     "sphinx==9.1.0",
     "myst-nb==1.3.0",
     "sphinx-book-theme==1.1.4",
+    "sphinx-copybutton==0.5.2",
     "pvlib==0.14.0",
     "pandas==2.3.3",
 ]


### PR DESCRIPTION
Code examples can be done in two ways:

Default style:
```python
def my_func():
    """
    Examples
    --------
    >>> x = np.random.randn(100_000)
    >>> y = 2 * x + np.random.randn(100_000)
    """
```

alternatively:

````python
def my_func():
    """
    Examples
    --------
    .. code-block:: python

        x = np.random.randn(100_000)
        y = 2 * x + np.random.randn(100_000)
    """
```

I've choosen to go with the former as this allows code examples to be tested with ``pytest --doctest-modules``
