### PR TITLE
Add testing of doc examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,6 @@ Repository = "https://github.com/assessingsolar/solarpy.git"
 Changelog = "https://github.com/assessingsolar/solarpy/blob/main/docs/source/whatsnew.md"
 
 [tool.pytest.ini_options]
-addopts = "--cov=solarpy --cov-fail-under=1 --cov-report=term-missing"
+addopts = "--cov=solarpy --cov-fail-under=1 --cov-report=term-missing --doctest-modules"
 pythonpath = ["src"]
+testpaths = ["tests", "src"]

--- a/src/solarpy/plotting/intraday_heatmap.py
+++ b/src/solarpy/plotting/intraday_heatmap.py
@@ -83,18 +83,20 @@ def plot_intraday_heatmap(
     Minute-resolution data over two weeks:
 
     >>> import numpy as np
+    >>> import solarpy
     >>> mins = np.arange(14 * 1440)
     >>> time = np.datetime64("2024-01-01") + mins * np.timedelta64(1, "m")
     >>> values = np.sin(mins / 1440 * np.pi) + np.random.randn(len(mins)) * 0.1
-    >>> fig, ax = plot_intraday_heatmap(time, values, cmap="viridis")
-    >>> fig.savefig("heatmap.png", dpi=150, bbox_inches="tight")
+    >>> fig, ax = solarpy.plotting.plot_intraday_heatmap(
+    ...     time, values, cmap="viridis")
 
     Ten-minute bins over one year:
 
     >>> mins = np.arange(365 * 144) * 10
     >>> time = np.datetime64("2024-01-01") + mins * np.timedelta64(1, "m")
     >>> values = np.random.randn(len(mins))
-    >>> fig, ax = plot_intraday_heatmap(time, values, resolution=10)
+    >>> fig, ax = solarpy.plotting.plot_intraday_heatmap(
+    ...     time, values, resolution=10)
     """
     time = np.asarray(time, dtype="datetime64[ns]")
     values = np.asarray(values, dtype=float)

--- a/src/solarpy/plotting/map.py
+++ b/src/solarpy/plotting/map.py
@@ -67,7 +67,9 @@ def plot_google_maps(
     --------
     Plot a satellite view of Copenhagen:
 
-    >>> fig, ax = plot_google_maps(55.6761, 12.5683, api_key="YOUR_KEY", zoom=12)
+    >>> import solarpy
+    >>> solarpy.plotting.plot_google_maps(
+    ...     55.6761, 12.5683, api_key="YOUR_KEY", zoom=12)  # doctest: +SKIP
     """
     if ax is None:
         fig, ax = plt.subplots()


### PR DESCRIPTION
Closes #14 

This modification makes pytest check that all examples in the documentation can run. It does not check the consistency of the output.