### PR TITLE
Conditionally add legend for horizon line

### DIFF
--- a/src/solarpy/plotting/multiplot.py
+++ b/src/solarpy/plotting/multiplot.py
@@ -634,7 +634,8 @@ def multiplot(times, data, meta, horizon=None, google_api_key=None, figsize=(24,
         if horizon is not None:
             ax.plot(horizon.index, horizon, c="r", label="Horizon line")
     axes["sun1"].set_xticks([])
-    axes["sun1"].legend(loc="upper right", frameon=False)
     axes["sun1"].set_xlabel(None)
+    if horizon is not None:
+        axes["sun1"].legend(loc="upper right", frameon=False)
 
     return fig, axes


### PR DESCRIPTION
Avoid the warning message due to the legend being added even when the horizon line is not available.

```
/usr/local/lib/python3.12/dist-packages/solarpy/plotting/multiplot.py:637: UserWarning: No artists with labels found to put in legend.  Note that artists whose label start with an underscore are ignored when legend() is called with no argument.
  axes["sun1"].legend(loc="upper right", frameon=False)
```