### PR TITLE
Fix x unit in plot_intraday_heatmap

### DIFF
--- a/src/solarpy/plotting/intraday_heatmap.py
+++ b/src/solarpy/plotting/intraday_heatmap.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 
@@ -124,8 +125,9 @@ def plot_intraday_heatmap(
     bin_idx = minutes // resolution
 
     # Contiguous date range — missing dates become all-NaN columns
-    all_dates = np.arange(dates.min(), dates.max() + np.timedelta64(1, "D"),
-                          np.timedelta64(1, "D"))
+    all_dates = np.arange(
+        dates.min(), dates.max() + np.timedelta64(1, "D"), np.timedelta64(1, "D")
+    )
     n_dates = len(all_dates)
 
     # ------------------------------------------------------------------ #
@@ -150,8 +152,11 @@ def plot_intraday_heatmap(
     # ------------------------------------------------------------------ #
     # pcolormesh expects cell edges: (n+1,) arrays                       #
     # ------------------------------------------------------------------ #
+    x_edges = mdates.date2num(all_dates.astype("datetime64[ms]").astype(object))
+    x_edges = np.append(x_edges, x_edges[-1] + 1)
+
     mesh = ax.pcolormesh(
-        np.arange(n_dates + 1),
+        x_edges,
         np.arange(n_bins + 1),
         matrix,
         cmap=cmap,
@@ -172,34 +177,18 @@ def plot_intraday_heatmap(
     # ------------------------------------------------------------------ #
     # X-axis — dynamic tick density based on date range                  #
     # ------------------------------------------------------------------ #
-    if n_dates <= 30:  # daily
-        tick_step = 1
-        date_fmt = "%Y-%m-%d"
-    elif n_dates <= 180:  # weekly
-        tick_step = 7
-        date_fmt = "%Y-%m-%d"
-    else:  # monthly (approx)
-        tick_step = 30
-        date_fmt = "%b %Y"
-
-    tick_positions = np.arange(0, n_dates, tick_step)
-    ax.set_xticks(tick_positions + 0.5)
-    ax.set_xticklabels(
-        [all_dates[i].astype("datetime64[D]").astype(object).strftime(date_fmt)
-         for i in tick_positions],
-        rotation=45,
-        ha="right",
-    )
+    ax.xaxis_date()
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y %b"))
+    ax.tick_params(axis="x", rotation=30)
 
     # ------------------------------------------------------------------ #
     # Y-axis — time of day (HH), ticks every 3 hours, midnight at bottom #
     # ------------------------------------------------------------------ #
-    bins_per_hour = 3*60 // resolution
+    bins_per_hour = 3 * 60 // resolution
     tick_bins = np.arange(0, n_bins, bins_per_hour)
     ax.set_yticks(tick_bins + 0.5)
     ax.set_yticklabels(
-        [f"{(b * resolution) // 60:02d}"
-         for b in tick_bins],
+        [f"{(b * resolution) // 60:02d}" for b in tick_bins],
     )
     ax.set_ylabel("Time of day")
 

--- a/src/solarpy/plotting/intraday_heatmap.py
+++ b/src/solarpy/plotting/intraday_heatmap.py
@@ -103,16 +103,6 @@ def plot_intraday_heatmap(
     >>> fig, ax = solarpy.plotting.plot_intraday_heatmap(
     ...     time, values, resolution=10)
     """
-    # ------------------------------------------------------------------ #
-    # Figure / axes                                                      #
-    # ------------------------------------------------------------------ #
-    if ax is None:
-        fig, ax = plt.subplots(figsize=(min(max(4, n_dates * 0.5), 8), 2))
-    fig = ax.figure
-
-    # ------------------------------------------------------------------ #
-    # times / values                                                     #
-    # ------------------------------------------------------------------ #
     time = np.asarray(time, dtype="datetime64[ns]")
     values = np.asarray(values, dtype=float)
 
@@ -126,6 +116,13 @@ def plot_intraday_heatmap(
         raise ValueError(f"resolution must evenly divide 1440, got {resolution}.")
 
     n_bins = 1440 // resolution
+
+    # ------------------------------------------------------------------ #
+    # Figure / axes                                                      #
+    # ------------------------------------------------------------------ #
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(min(max(4, n_dates * 0.5), 8), 2))
+    fig = ax.figure
 
     # ------------------------------------------------------------------ #
     # Extract date and bin index                                         #

--- a/src/solarpy/plotting/intraday_heatmap.py
+++ b/src/solarpy/plotting/intraday_heatmap.py
@@ -118,13 +118,6 @@ def plot_intraday_heatmap(
     n_bins = 1440 // resolution
 
     # ------------------------------------------------------------------ #
-    # Figure / axes                                                      #
-    # ------------------------------------------------------------------ #
-    if ax is None:
-        fig, ax = plt.subplots(figsize=(min(max(4, n_dates * 0.5), 8), 2))
-    fig = ax.figure
-
-    # ------------------------------------------------------------------ #
     # Extract date and bin index                                         #
     # ------------------------------------------------------------------ #
     dates = time.astype("datetime64[D]")
@@ -136,6 +129,13 @@ def plot_intraday_heatmap(
         dates.min(), dates.max() + np.timedelta64(1, "D"), np.timedelta64(1, "D")
     )
     n_dates = len(all_dates)
+
+    # ------------------------------------------------------------------ #
+    # Figure / axes                                                      #
+    # ------------------------------------------------------------------ #
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(min(max(4, n_dates * 0.5), 8), 2))
+    fig = ax.figure
 
     # ------------------------------------------------------------------ #
     # Build n_bins × n_dates matrix, averaging duplicate timestamps      #

--- a/src/solarpy/plotting/intraday_heatmap.py
+++ b/src/solarpy/plotting/intraday_heatmap.py
@@ -103,6 +103,16 @@ def plot_intraday_heatmap(
     >>> fig, ax = solarpy.plotting.plot_intraday_heatmap(
     ...     time, values, resolution=10)
     """
+    # ------------------------------------------------------------------ #
+    # Figure / axes                                                      #
+    # ------------------------------------------------------------------ #
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(min(max(4, n_dates * 0.5), 8), 2))
+    fig = ax.figure
+
+    # ------------------------------------------------------------------ #
+    # times / values                                                     #
+    # ------------------------------------------------------------------ #
     time = np.asarray(time, dtype="datetime64[ns]")
     values = np.asarray(values, dtype=float)
 
@@ -141,13 +151,6 @@ def plot_intraday_heatmap(
     np.add.at(count, (bin_idx, date_idx), 1)
 
     matrix = np.where(count > 0, total / count, np.nan)
-
-    # ------------------------------------------------------------------ #
-    # Figure / axes                                                      #
-    # ------------------------------------------------------------------ #
-    if ax is None:
-        fig, ax = plt.subplots(figsize=(min(max(4, n_dates * 0.5), 8), 2))
-    fig = ax.figure
 
     # ------------------------------------------------------------------ #
     # pcolormesh expects cell edges: (n+1,) arrays                       #

--- a/src/solarpy/plotting/multiplot.py
+++ b/src/solarpy/plotting/multiplot.py
@@ -196,7 +196,6 @@ def multiplot(times, data, meta, horizon=None, google_api_key=None, figsize=(24,
     for ax, c in zip(axes["line"], components):
         ax.plot(data[c].resample("5min").max(), lw=0.5)
         ax.set_ylabel(f"{c.upper()} [W/m²]")
-        ax.set_xlim(ts_xlim)
         ax.set_ylim(0, None)
 
     # Determine sunrise and sunset
@@ -301,17 +300,20 @@ def multiplot(times, data, meta, horizon=None, google_api_key=None, figsize=(24,
 
     for ax in axes["ts_scatter"]:
         ax.axhline(1, linestyle="--", **limit_line_params)
-        ax.set_xlim(ts_xlim)
 
     fig.align_ylabels(axes["line"] + axes["heatmap"] + axes["ts_scatter"])
-    # Remove xticks for time series plots
-    [ax.set_xticks([]) for ax in axes["line"] + axes["heatmap"] + axes["ts_scatter"]]
+
+    # Set xticks and xlimits
     ts_xticks = pd.date_range(ts_xlim[0], ts_xlim[1], freq="MS")
+    ts_xticklabels = ts_xticks.strftime("%Y %b")
+    for ax in axes["line"] + axes["heatmap"] + axes["ts_scatter"]:
+        ax.set_xticks(ts_xticks)
+        ax.set_xticklabels([])
+        ax.set_xlim(ts_xlim)
     # Set xticks for the bottom time series plot
-    axes["ts_scatter"][2].set_xticks(
-        ts_xticks, ts_xticks.strftime("%b %Y"), ha="right", rotation=30
+    axes["ts_scatter"][-1].set_xticks(
+        ts_xticks, ts_xticklabels, ha="right", rotation=30
     )
-    axes["ts_scatter"][2].set_xlim(ts_xlim)
 
     # Scatter plot settings
     scatter_params = {
@@ -645,17 +647,18 @@ def multiplot(times, data, meta, horizon=None, google_api_key=None, figsize=(24,
     ):
         mask = value < 1
         # TODO: Make a better filtering
-        plot_shading_heatmap(
-            value=value[mask],
-            solar_azimuth=data["solar_azimuth"][mask],
-            solar_elevation=90 - data["solar_zenith"][mask],
-            ax=ax,
-            cmap="viridis",
-            norm=Normalize(vmin=0, vmax=0.7),
-            colorbar_label=clabel,
-            northern_hemisphere=meta["latitude"] > 0,
-            horizon=horizon,
-        )
+        if sum(mask) > 0:  # only plot if array is not empty
+            plot_shading_heatmap(
+                value=value[mask],
+                solar_azimuth=data["solar_azimuth"][mask],
+                solar_elevation=90 - data["solar_zenith"][mask],
+                ax=ax,
+                cmap="viridis",
+                norm=Normalize(vmin=0, vmax=0.7),
+                colorbar_label=clabel,
+                northern_hemisphere=meta["latitude"] > 0,
+                horizon=horizon,
+            )
     axes["sun1"].set_xticks([])
     axes["sun1"].set_xlabel(None)
     if horizon is not None:

--- a/src/solarpy/plotting/plot_scatter.py
+++ b/src/solarpy/plotting/plot_scatter.py
@@ -19,12 +19,19 @@ def plot_scatter_heatmap(
     ax=None,
     **kwargs,
 ):
-    x, y = np.asarray(x), np.asarray(y)
-    finite = np.isfinite(x) & np.isfinite(y)
-
     if ax is None:
         fig, ax = plt.subplots()
     fig = ax.figure
+
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+
+    # Allow for plotting when all values are nan
+    if len(x) == 0:
+        return fig, ax
+
+    x, y = np.asarray(x), np.asarray(y)
+    finite = np.isfinite(x) & np.isfinite(y)
 
     H, xedges, yedges = np.histogram2d(
         x[finite], y[finite], bins=(xbins, ybins), range=(xlim, ylim)


### PR DESCRIPTION
Previously, the x-axis started at 0 and ended at the number of days. This is not consistent with other matplotlib plots where time is in days since the epoch. This PR fixes this such that xlim can be applied to the figure in the same way as traditional matplotlib figures.