### PR TITLE
Remove mention of flags from bsrn_limits function

### DIFF
--- a/docs/examples/quality/plot_bsrn_closure.py
+++ b/docs/examples/quality/plot_bsrn_closure.py
@@ -21,7 +21,6 @@ irradiance measurements.
 # The example data is from DTU's station in Lyngby, Denmark north of Copenhagen.
 # The data is from 2023 and includes measurements of GHI, DHI, and DNI at a 1-minute resolution.
 
-import matplotlib.pyplot as plt
 import pvlib
 import solarpy
 

--- a/src/solarpy/quality/limits.py
+++ b/src/solarpy/quality/limits.py
@@ -22,8 +22,7 @@ def bsrn_limits(solar_zenith, dni_extra, limits):
         upper = scale * DNI_extra * cos(solar_zenith) ^ exponent + offset
 
     where *scale*, *exponent*, and *offset* are coefficients that depend on
-    the variable and test level. A value is flagged if it lies outside
-    [lower, upper].
+    the variable and test level.
 
     Parameters
     ----------


### PR DESCRIPTION
Removed redundant sentence about flagging values outside limits.